### PR TITLE
HPCC-14437 Replace FBSTRING_PluginFileName with FBSTRING_PluginName

### DIFF
--- a/cmake/Mac.cmake
+++ b/cmake/Mac.cmake
@@ -103,7 +103,7 @@ MACRO(add_mac_plugin PROJECT_NAME PLIST_TEMPLATE STRINGS_TEMPLATE LOCALIZED_TEMP
 
     string(REPLACE " " "\ " FB_ESC_ROOT_DIR ${FB_ROOT_DIR})
     set_target_properties(${PROJECT_NAME} PROPERTIES
-        OUTPUT_NAME ${FBSTRING_PluginFileName}
+        OUTPUT_NAME ${FBSTRING_PluginName}
         BUNDLE 1
         BUNDLE_EXTENSION plugin
         XCODE_ATTRIBUTE_WRAPPER_EXTENSION plugin  #sets the extension to .plugin


### PR DESCRIPTION
With ${FBSTRING_PluginName} in cmake/Mac.cmake it will generate expected project HPCCSystemsGraphViewControll_x86_64.plugin  instead of npHPCCSystemsGraphViewControll.plugin

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com

@GordonSmith please review
